### PR TITLE
Fix various issues

### DIFF
--- a/HImodel.c
+++ b/HImodel.c
@@ -990,7 +990,7 @@ static void *scan_thread(void *args)
       tbps += plen-rep;
 
       ncnt += 1;
-      err   = (10000*err)/(plen-rep);
+      err   = (10000*err)/((plen-rep) == 0 ? 1 : (plen-rep));
       plen += KMER-1;
       rsum += plen;
       rsqr += plen*plen;

--- a/HIsim.c
+++ b/HIsim.c
@@ -2205,7 +2205,7 @@ static int64 Shotgun(Genome *gene, int ploid, double prate)
 
           do
             len = sample_read_length(&erate);
-          while (len < RSHORT);
+          while (len < tooshort);
 
           rbeg = nbeg;
           rend = nbeg + len;

--- a/HIsim.c
+++ b/HIsim.c
@@ -2465,7 +2465,7 @@ int main(int argc, char *argv[])
     COVERAGE  = 50.;
     RMEAN     = -1;
     RSDEV     = -1;
-    RSHORT    = 0;
+    RSHORT    = 4000;
     SEED      = getpid();
     READ_OUT  = stdout;
     WIDTH     = 100;


### PR DESCRIPTION
 * `RSHORT` was initialised with 0 as opposed to 4000 as advertised in the documentation.
 * Reads were generated shorter than `tooshort`, falsely triggering the logic to abort at the end of a scaffold.
 * I fixed the floating point exception as described in #1.